### PR TITLE
Remove unrequired PATH prepend for Homebrew

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -41,9 +41,6 @@ fi
 
 [ -d ~/bin ] && export PATH=~/bin:"$PATH"
 
-# Homebrew
-export PATH="/usr/local/bin:$PATH"
-
 # Git
 export PATH="/opt/git/bin:$PATH"
 


### PR DESCRIPTION
Before:
<img width="622" alt="duplicate-homebrew-path" src="https://cloud.githubusercontent.com/assets/680789/19044659/3e967fd6-8963-11e6-9502-0e186542566f.png">

After:
<img width="581" alt="single-homebrew-path" src="https://cloud.githubusercontent.com/assets/680789/19044707/727e4e1e-8963-11e6-8b82-1d4c600f266e.png">

