### PR TITLE
Run chruby & rbenv after prepending homebrew path

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -28,17 +28,6 @@ export VISUAL=vim
 export EDITOR=$VISUAL
 export GIT_EDITOR=$VISUAL
 
-# CHRUBY
-if [ -d "/usr/local/share/chruby" ]; then
-  source /usr/local/share/chruby/chruby.sh
-  source /usr/local/share/chruby/auto.sh
-
-# RBENV
-elif [ -d "$HOME/.rbenv" ]; then
-  export PATH="$HOME/.rbenv/bin:$PATH"
-  eval "$(rbenv init - --no-rehash)"
-fi
-
 [ -d ~/bin ] && export PATH=~/bin:"$PATH"
 
 # Homebrew
@@ -55,6 +44,17 @@ export PATH="/usr/local/pgsql/bin:$PATH"
 
 # load dotfiles scripts
 export PATH="$HOME/.bin:$PATH"
+
+# CHRUBY
+if [ -d "/usr/local/share/chruby" ]; then
+  source /usr/local/share/chruby/chruby.sh
+  source /usr/local/share/chruby/auto.sh
+
+# RBENV
+elif [ -d "$HOME/.rbenv" ]; then
+  export PATH="$HOME/.rbenv/bin:$PATH"
+  eval "$(rbenv init - --no-rehash)"
+fi
 
 # aliases
 [[ -f ~/.aliases ]] && source ~/.aliases


### PR DESCRIPTION
This ensures that the correct ruby paths are prepended before homebrew. The
VIM 8 homebrew recipe installs ruby as a dependency which was getting loaded
before the rubies configured in chruby & rbenv when a new terminal was
opened.

**Before:**
<img width="661" alt="chruby-before" src="https://cloud.githubusercontent.com/assets/680789/19044830/e3d5a3c8-8963-11e6-8211-0c38ce3fb884.png">

**After:**
<img width="622" alt="chruby-after" src="https://cloud.githubusercontent.com/assets/680789/19044773/b31d5186-8963-11e6-92c6-429a40810cf1.png">
